### PR TITLE
Fix weekly menu responsive layout

### DIFF
--- a/src/pages/WeeklyMenu.tsx
+++ b/src/pages/WeeklyMenu.tsx
@@ -122,7 +122,20 @@ const WeeklyMenu: React.FC = () => {
         </Box>
       </Box>
 
-      <Box sx={{ display: 'grid', gridTemplateColumns: 'repeat(7, 1fr)', gap: 2 }}>
+      <Box
+        sx={{
+          display: 'grid',
+          gap: 2,
+          // Responsive layout: 1 column on phones up to 7 columns on large desktops
+          gridTemplateColumns: {
+            xs: 'repeat(1, 1fr)',
+            sm: 'repeat(2, 1fr)',
+            md: 'repeat(3, 1fr)',
+            lg: 'repeat(4, 1fr)',
+            xl: 'repeat(7, 1fr)',
+          },
+        }}
+      >
         {days.map((day) => (
           <Paper key={day} sx={{ p: 2 }}>
             <Typography variant="h6" gutterBottom sx={{ textAlign: 'center' }}>


### PR DESCRIPTION
Adjust weekly menu grid columns responsively to prevent horizontal overflow on mobile.

---
<a href="https://cursor.com/background-agent?bcId=bc-c1f031ce-92cc-45cc-80fe-35336f2b239c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c1f031ce-92cc-45cc-80fe-35336f2b239c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>